### PR TITLE
Switch camera fixed, now we can mute video after switching.

### DIFF
--- a/src/web_app/js/call.js
+++ b/src/web_app/js/call.js
@@ -289,9 +289,7 @@ Call.prototype.switchCamera = function (deviceId) {
         let oldVideoStreamTrack = this.localStream_.getVideoTracks()[0];
         // After a successful switch we remove the old stream and add the new one.
         this.localStream_.removeTrack(oldVideoStreamTrack);
-        console.log(oldVideoStreamTrack.id);
         this.localStream_.addTrack(videoTrackToSwitchTo);
-        console.log(this.localStream_.getVideoTracks()[0].id);
       });
 
 


### PR DESCRIPTION
**Description**
The switchCamera function that was there before in call.js was replacing track but it was not replacing tracks in the local stream because of which the video pause stopped working after calling switchCamera at least once.
